### PR TITLE
scssified some css to at least leverage scss nesting

### DIFF
--- a/client/app/app.component.scss
+++ b/client/app/app.component.scss
@@ -15,7 +15,7 @@
 }
 .hidden {
   color: #fff;
-}
-.hidden:hover {
-  color: #888;
+  &:hover {
+    color: #888;
+  }
 }

--- a/client/app/user/user-login/user-login.component.scss
+++ b/client/app/user/user-login/user-login.component.scss
@@ -19,27 +19,29 @@ h2.no-padding {
   width: 100%;
   height: 20%;
   padding: 0.25em 0.5em;
+
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
 }
 
-.row:after {
-  content: '';
-  display: table;
-  clear: both;
-}
+.cell {
+  &.label {
+    float: left;
+    width: 25%;
+  }
 
-.cell.label {
-  float: left;
-  width: 25%;
-}
+  &.input {
+    float: left;
+    width: 75%;
 
-.cell.input {
-  width: 75%;
-  float: left;
-}
-
-.cell.input .user {
-  border-radius: 1em;
-  padding: 0.5em 1em;
+    .user {
+      border-radius: 1em;
+      padding: 0.5em 1em;
+    }
+  }
 }
 
 .user {

--- a/client/app/user/user-register/user-register.component.scss
+++ b/client/app/user/user-register/user-register.component.scss
@@ -19,27 +19,29 @@ h2.no-padding {
   width: 100%;
   height: 20%;
   padding: 0.25em 0.5em;
+
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
 }
 
-.row:after {
-  content: '';
-  display: table;
-  clear: both;
-}
+.cell {
+  &.label {
+    float: left;
+    width: 25%;
+  }
 
-.cell.label {
-  float: left;
-  width: 25%;
-}
+  &.input {
+    float: left;
+    width: 75%;
 
-.cell.input {
-  width: 75%;
-  float: left;
-}
-
-.cell.input .user {
-  border-radius: 1em;
-  padding: 0.5em 1em;
+    .user {
+      border-radius: 1em;
+      padding: 0.5em 1em;
+    }
+  }
 }
 
 .user {

--- a/client/styles.scss
+++ b/client/styles.scss
@@ -4,12 +4,16 @@
   font-family: HyliaSerif;
   src: url('./assets/fonts/HyliaSerifBeta.otf');
 }
-body.dark {
-  background-color: rgb(238, 177, 253);
+
+body {
+  &.dark {
+    background-color: rgb(238, 177, 253);
+  }
+  &.light {
+    background-color: rgb(252, 252, 174);
+  }
 }
-body.light {
-  background-color: rgb(252, 252, 174);
-}
+
 h1,
 h2,
 h3,
@@ -18,11 +22,13 @@ h5,
 h6 {
   font-family: HyliaSerif;
 }
+
 h1 {
   color: rgb(19, 85, 41);
   font-size: 175%;
   text-align: center;
 }
+
 h2,
 h3 {
   color: #444;
@@ -32,19 +38,24 @@ h3 {
   margin-top: 2px;
   margin-bottom: 2px;
 }
+
 body {
   margin: 2em;
+  color: #888;
+  font-family: Cambria, Georgia;
 }
-body,
+
 input[text],
 button {
   color: #888;
   font-family: Cambria, Georgia;
 }
+
 .details {
   width: 33%;
   float: left;
 }
+
 .skills {
   width: 67%;
   float: left;
@@ -59,49 +70,57 @@ button {
   color: rgba(0, 0, 0, 0.666);
   float: right;
 }
+
 table {
   width: 100%;
   background-color: inherit;
 }
-tr.weapon:nth-child(3n + 1) {
-  background-color: rgba(233, 150, 150, 0.74);
-  color: black;
+
+tr.weapon {
+  &:nth-child(3n + 1) {
+    background-color: rgba(233, 150, 150, 0.74);
+    color: black;
+  }
+  &:nth-child(3n + 2) {
+    background-color: rgba(150, 233, 150, 0.74);
+    color: black;
+  }
+  &:nth-child(3n) {
+    background-color: rgba(150, 150, 233, 0.74);
+    color: black;
+  }
 }
-tr.weapon:nth-child(3n + 2) {
-  background-color: rgba(150, 233, 150, 0.74);
-  color: black;
-}
-tr.weapon:nth-child(3n) {
-  background-color: rgba(150, 150, 233, 0.74);
-  color: black;
-}
+
 td {
   margin: 5px;
   padding: 5px;
   text-align: center;
   word-wrap: break-word;
+  &.name,
+  &.mod {
+    text-align: left;
+  }
 }
-td.name {
-  text-align: left;
-}
-td.mod {
-  text-align: left;
-}
+
 th {
   margin: 5px;
   width: 3.5em;
 }
+
 .column-holder::after {
   content: '';
   display: table;
   clear: both;
 }
+
 input {
   width: 50px;
 }
+
 td.total {
   font-weight: bold;
 }
+
 .modal {
   display: none; /* Hidden by default */
   position: fixed; /* Stay in place */
@@ -115,6 +134,7 @@ td.total {
   background-color: rgb(0, 0, 0); /* Fallback color */
   background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
 }
+
 .showModal {
   display: block;
 }
@@ -127,12 +147,10 @@ td.total {
   border-bottom: solid black 1px;
 }
 
-/* Modal Body */
 .modal-body {
   padding: 2px 16px;
 }
 
-/* Modal Content */
 .modal-content {
   position: relative;
   background-color: #fefefe;
@@ -158,6 +176,7 @@ td.total {
   padding-right: 0%;
   padding-left: 0%;
 }
+
 .tab {
   color: #444;
   border: none;
@@ -171,38 +190,39 @@ td.total {
   float: left;
   text-align: center;
   transition: 0.6s;
-}
-.tab:hover {
-  background-color: #229e22;
+  &:hover {
+    background-color: #229e22;
+  }
 }
 
-/* The Close Button */
 .close {
   color: #aaa;
   float: right;
   font-size: 28px;
   font-weight: bold;
-}
-
-.close:hover,
-.close:focus {
-  color: black;
-  text-decoration: none;
-  cursor: pointer;
+  &:hover,
+  &:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+  }
 }
 
 .din {
   background-color: rgba(233, 150, 150, 0.74);
   color: black;
 }
+
 .farore {
   background-color: rgba(150, 233, 150, 0.74);
   color: black;
 }
+
 .nayru {
   background-color: rgba(150, 150, 233, 0.74);
   color: black;
 }
+
 .accordian {
   background: #eee;
   color: #444444;
@@ -214,21 +234,25 @@ td.total {
   transition: 0.4s;
   padding-top: 2px;
   padding-bottom: 2px;
+  &:hover {
+    background-color: #ccc;
+  }
 }
-.accordian:hover {
-  background-color: #ccc;
-}
+
 .panel {
   padding: 5px 0px;
   background-color: inherit;
   display: none;
 }
+
 .active {
   display: block;
 }
+
 .user {
   width: 8em;
 }
+
 .form {
   width: 40%;
 }
@@ -263,6 +287,7 @@ td.total {
     top: -300px;
     opacity: 0;
   }
+
   to {
     top: 0;
     opacity: 1;
@@ -270,15 +295,9 @@ td.total {
 }
 
 @media (max-width: 900px) {
-  .character-column {
-    width: 100%;
-  }
-  .details-column {
-    width: 100%;
-  }
-  .skills {
-    width: 100%;
-  }
+  .character-column,
+  .details-column,
+  .skills,
   .details {
     width: 100%;
   }
@@ -295,8 +314,3 @@ td.total {
     margin-bottom: 25%;
   }
 }
-
-/* everywhere else */
-/* {
-  font-family: Arial, Helvetica, sans-serif;
-}*/


### PR DESCRIPTION
For this PR I just added some nesting to help with Issue #100, but pretty much the entire `user-registration.component.scss` file can be \@imported into `user-login.component.scss` or vise-versa, but then it should be moved into it's own generic file imo and that would require changing the css file/folder structure which is a liberty I didn't want to take.

Something like 
```
+ app/
 |--shared/
 |----scss/registration.scss 
```

that is then imported into the two above mentioned files? Maybe? 